### PR TITLE
Search adventures

### DIFF
--- a/routes/studentRoute.js
+++ b/routes/studentRoute.js
@@ -31,9 +31,15 @@ router.get('/search/:searchTerm', (req, res, next) => {
   let searchTerm = req.params.searchTerm;
   return Adventure.find({title: {$regex: searchTerm}})
     .then(adventures => {
+      if(adventures.length === 0){
+        return Promise.reject(new Error('No Matching Adventures Found'));
+      }
       return res.json(adventures);
     })
     .catch(err => {
+      if(err.message === 'No Matching Adventures Found'){
+        err.status = 404
+      }
       next(err);
     })
 })

--- a/routes/studentRoute.js
+++ b/routes/studentRoute.js
@@ -15,6 +15,30 @@ const jwtAuth = passport.authenticate('jwt', { session: false });
 //fullroute: '{BASE_URL}/api/student'
 // 5c9ce70225a9ad1651bf9fe6
 
+
+
+router.get('/search', (req, res, next) => {
+  return Adventure.find()
+    .then(adventures => {
+      return res.json(adventures)
+    })
+    .catch(err => {
+      next(err);
+    })
+});
+
+router.get('/search/:searchTerm', (req, res, next) => {
+  let searchTerm = req.params.searchTerm;
+  return Adventure.find({title: {$regex: searchTerm}})
+    .then(adventures => {
+      return res.json(adventures);
+    })
+    .catch(err => {
+      next(err);
+    })
+})
+
+
 router.get('/adventure/:id', (req, res, next) => {
   const adventureId = req.params.id;
   if (!mongoose.Types.ObjectId.isValid(adventureId)) {


### PR DESCRIPTION

Added two new routes to the studentRoute.js file. the routes are /search and /search/:searchTerm, with the former returning all adventures and the latter returning adventures whose titles contain a searchTerm inputted by the user. No error handling outside of the basics as of yet.


search/:searchTerm route now returns a No Matching Adventures Found error message if the search term does not match anything.